### PR TITLE
Small fixes to detection of package installed nix and nixbld users

### DIFF
--- a/archlinux-nix
+++ b/archlinux-nix
@@ -22,8 +22,12 @@ oops() {
   exit 1
 }
 
+pm_path() {
+    which -a nix 2>/dev/null | grep '^/usr' | head -n 1
+}
+
 pm_installed() {
-  which nix 2>/dev/null | grep -q '^/usr'
+  [ -n "$(pm_path)" ]
 }
 
 nix_installed() {
@@ -301,7 +305,7 @@ load_daemon() {
 
 do_status() {
   if pm_installed; then
-    echo "Nix installed via package manager ($(which nix))"
+    echo "Nix installed via package manager ($(pm_path))"
   elif nix_installed; then
     echo "Nix self-installed"
   else

--- a/archlinux-nix
+++ b/archlinux-nix
@@ -148,12 +148,12 @@ append_sandbox_paths() {
 
 group_exists() {
   local group=$1
-  [[ -n $(cut -d: -f1 /etc/group | grep -w $group) ]]
+  getent group $group > /dev/null
 }
 
 user_exists() {
   local user=$1
-  [[ -n $(cut -d: -f1 /etc/passwd | grep -w $user) ]]
+  getent passwd $user > /dev/null
 }
 
 create_users() {


### PR DESCRIPTION
If a user installs nix via nix, then which nix will show that nix but not the system nix prevent the detection of nix.

And in environments with nss modules, nixbld users may not be in /etc/passwd or /etc/group, so do the detection of those the same ways apps do.