### PR TITLE
Remove non-standard paths from sandbox

### DIFF
--- a/archlinux-nix
+++ b/archlinux-nix
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-sandbox_binaries="bash bzip2 env gzip mkdir mv tar tr xz"
-sandbox_packages="bash bzip2 coreutils gnutar gzip xz"
+sandbox_binaries=""
+sandbox_packages="bash"
 default_nixos_version="19.09"
 default_group="nixbld"
 conf_file=/etc/nix/nix.conf


### PR DESCRIPTION
A normal Nix installation (e.g. on NixOS) only adds `/bin/sh` to the sandbox. This script adds a few other paths that can cause builds to succeed when they wouldn't on NixOS, for example here: https://github.com/NixOS/nixpkgs/pull/74580#issuecomment-559759696

This PR removes the non-standard paths from the sandbox.