### PR TITLE
Replace deprecated build-sandbox-paths option with sandbox-paths

### DIFF
--- a/archlinux-nix
+++ b/archlinux-nix
@@ -122,7 +122,7 @@ sandbox_path() {
 }
 
 sandbox_paths() {
-  [ -f "$conf_file" ] && grep '^\s*build-sandbox-paths\s*=' "$conf_file" | sed 's/^[^=]*=\s*\(.*\)$/\1/'
+  [ -f "$conf_file" ] && grep '^\s*\(build-\)\?sandbox-paths\s*=' "$conf_file" | sed 's/^[^=]*=\s*\(.*\)$/\1/'
 }
 
 gen_sandbox_paths() {
@@ -130,12 +130,12 @@ gen_sandbox_paths() {
   for bin in $sandbox_binaries; do
     paths+=" /usr/bin/$bin=$(sandbox_path $bin)"
   done
-  echo "build-sandbox-paths = $paths"
+  echo "sandbox-paths = $paths"
 }
 
 delete_sandbox_paths() {
   if [ -f "$conf_file" ]; then
-    sed -i '/^\s*build-sandbox-paths\s*=/ d' "$conf_file"
+    sed -i '/^\s*\(build-\)\?sandbox-paths\s*=/ d' "$conf_file"
   fi
 }
 


### PR DESCRIPTION
The `build-sandbox-paths` option was renamed to `sandbox-paths` in Nix 2.0, with the former remaining as a deprecated alias.

This PR switches the script from using `build-sandbox-paths` to `sandbox-paths`, automatically migrating existing configurations.