### PR TITLE
Fixed script shebang

### DIFF
--- a/archlinux-nix
+++ b/archlinux-nix
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 sandbox_binaries=""
 sandbox_packages="bash"


### PR DESCRIPTION
Script is not POSIX compliant, thus running it trough a POSIX only shell breaks it.